### PR TITLE
Improve auth service and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# OneMinute Authentication Service
+
+This repository contains a Spring Boot service that provides user registration and authentication using JWT tokens.
+
+## Prerequisites
+
+- Java 21
+- Maven
+- MySQL database
+
+## Configuration
+
+The service reads sensitive information from environment variables. The following variables can be set:
+
+- `DB_URL` - JDBC connection string (default `jdbc:mysql://localhost:3306/authdb`)
+- `DB_USERNAME` - database username (default `root`)
+- `DB_PASSWORD` - database password (default `root`)
+- `JWT_SECRET` - secret key used to sign tokens (required)
+- `JWT_EXPIRATION` - token lifetime in milliseconds (default `86400000`)
+
+You can define these in an `.env` file or export them in your shell before running the service.
+
+## Building and Running
+
+```bash
+cd services/auth-service
+./mvnw spring-boot:run
+```
+
+The application will start on `http://localhost:8080`.
+
+## Running Tests
+
+```bash
+./mvnw test
+```

--- a/services/auth-service/src/main/java/com/oneminute/auth/dto/RegisterRequest.java
+++ b/services/auth-service/src/main/java/com/oneminute/auth/dto/RegisterRequest.java
@@ -3,7 +3,6 @@ package com.oneminute.auth.dto;
 import lombok.*;
 
 @Data
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder

--- a/services/auth-service/src/main/java/com/oneminute/auth/entity/User.java
+++ b/services/auth-service/src/main/java/com/oneminute/auth/entity/User.java
@@ -3,14 +3,16 @@ package com.oneminute.auth.entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -37,6 +39,17 @@ public class User {
     @CreationTimestamp
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", username='" + username + '\'' +
+                ", email='" + email + '\'' +
+                ", role=" + role +
+                ", createdAt=" + createdAt +
+                '}';
+    }
 
     public enum Role{
         USER,

--- a/services/auth-service/src/main/java/com/oneminute/auth/exception/EmailAlreadyTakenException.java
+++ b/services/auth-service/src/main/java/com/oneminute/auth/exception/EmailAlreadyTakenException.java
@@ -1,0 +1,7 @@
+package com.oneminute.auth.exception;
+
+public class EmailAlreadyTakenException extends RuntimeException {
+    public EmailAlreadyTakenException(String message) {
+        super(message);
+    }
+}

--- a/services/auth-service/src/main/java/com/oneminute/auth/exception/GlobalExceptionHandler.java
+++ b/services/auth-service/src/main/java/com/oneminute/auth/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.oneminute.auth.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EmailAlreadyTakenException.class)
+    public ResponseEntity<String> handleEmailAlreadyTaken(EmailAlreadyTakenException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<String> handleInvalidCredentials(InvalidCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
+}

--- a/services/auth-service/src/main/java/com/oneminute/auth/exception/InvalidCredentialsException.java
+++ b/services/auth-service/src/main/java/com/oneminute/auth/exception/InvalidCredentialsException.java
@@ -1,0 +1,10 @@
+package com.oneminute.auth.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException() {
+        super("Invalid credentials");
+    }
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/services/auth-service/src/main/java/com/oneminute/auth/service/AuthService.java
+++ b/services/auth-service/src/main/java/com/oneminute/auth/service/AuthService.java
@@ -5,6 +5,8 @@ import com.oneminute.auth.dto.AuthResponse;
 import com.oneminute.auth.dto.LoginRequest;
 import com.oneminute.auth.dto.RegisterRequest;
 import com.oneminute.auth.entity.User;
+import com.oneminute.auth.exception.EmailAlreadyTakenException;
+import com.oneminute.auth.exception.InvalidCredentialsException;
 import com.oneminute.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,7 +22,7 @@ public class AuthService {
 
     public AuthResponse register(RegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new RuntimeException("Email already taken");
+            throw new EmailAlreadyTakenException("Email already taken");
         }
         var user = User.builder()
                 .username(request.getUsername())
@@ -40,9 +42,9 @@ public class AuthService {
 
     public AuthResponse authenticate(LoginRequest request) {
         var user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(InvalidCredentialsException::new);
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new RuntimeException("Incorrect password");
+            throw new InvalidCredentialsException();
         }
         var token = jwtService.generateToken(user);
 

--- a/services/auth-service/src/main/resources/application.yml
+++ b/services/auth-service/src/main/resources/application.yml
@@ -3,9 +3,9 @@ server:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/authdb
-    username: root
-    password: root
+    url: ${DB_URL:jdbc:mysql://localhost:3306/authdb}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:root}
   jpa:
     hibernate:
       ddl-auto: update
@@ -13,5 +13,5 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
 jwt:
-  secret: mysupersecretkey1234567890123456
-  expiration: 86400000 # 1 day in ms
+  secret: ${JWT_SECRET}
+  expiration: ${JWT_EXPIRATION:86400000} # 1 day in ms

--- a/services/auth-service/src/test/java/com/oneminute/auth/service/AuthServiceTest.java
+++ b/services/auth-service/src/test/java/com/oneminute/auth/service/AuthServiceTest.java
@@ -1,0 +1,115 @@
+package com.oneminute.auth.service;
+
+import com.oneminute.auth.dto.AuthResponse;
+import com.oneminute.auth.dto.LoginRequest;
+import com.oneminute.auth.dto.RegisterRequest;
+import com.oneminute.auth.entity.User;
+import com.oneminute.auth.exception.EmailAlreadyTakenException;
+import com.oneminute.auth.exception.InvalidCredentialsException;
+import com.oneminute.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void registerSuccess() {
+        RegisterRequest request = RegisterRequest.builder()
+                .username("john")
+                .email("john@example.com")
+                .password("pass")
+                .build();
+        given(userRepository.existsByEmail(request.getEmail())).willReturn(false);
+        given(passwordEncoder.encode(request.getPassword())).willReturn("hashed");
+        given(jwtService.generateToken(any(User.class))).willReturn("token");
+
+        AuthResponse response = authService.register(request);
+
+        assertEquals("token", response.getToken());
+    }
+
+    @Test
+    void registerEmailTaken() {
+        RegisterRequest request = RegisterRequest.builder()
+                .username("john")
+                .email("john@example.com")
+                .password("pass")
+                .build();
+        given(userRepository.existsByEmail(request.getEmail())).willReturn(true);
+
+        assertThrows(EmailAlreadyTakenException.class, () -> authService.register(request));
+    }
+
+    @Test
+    void authenticateSuccess() {
+        LoginRequest request = LoginRequest.builder()
+                .email("john@example.com")
+                .password("pass")
+                .build();
+        User user = User.builder()
+                .email(request.getEmail())
+                .password("hashed")
+                .role(User.Role.USER)
+                .build();
+        given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(request.getPassword(), user.getPassword())).willReturn(true);
+        given(jwtService.generateToken(user)).willReturn("token");
+
+        AuthResponse response = authService.authenticate(request);
+
+        assertEquals("token", response.getToken());
+    }
+
+    @Test
+    void authenticateInvalidCredentials() {
+        LoginRequest request = LoginRequest.builder()
+                .email("john@example.com")
+                .password("pass")
+                .build();
+        given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.empty());
+
+        assertThrows(InvalidCredentialsException.class, () -> authService.authenticate(request));
+    }
+
+    @Test
+    void authenticateWrongPassword() {
+        LoginRequest request = LoginRequest.builder()
+                .email("john@example.com")
+                .password("wrong")
+                .build();
+        User user = User.builder()
+                .email(request.getEmail())
+                .password("hashed")
+                .role(User.Role.USER)
+                .build();
+        given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(request.getPassword(), user.getPassword())).willReturn(false);
+
+        assertThrows(InvalidCredentialsException.class, () -> authService.authenticate(request));
+    }
+}


### PR DESCRIPTION
## Summary
- secure config using environment variables
- update documentation with config instructions
- simplify Lombok usage in RegisterRequest
- prevent password leaks in User.toString
- add custom exceptions and global handler
- update AuthService to use new exceptions
- create service unit tests

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6885e8e9de50832f9aa25bd631c27022